### PR TITLE
L'absence de valeur pour la clé "options.workspace.path" créé une runtime exception

### DIFF
--- a/src/main/java/com/zestedesavoir/zestwriter/utils/Configuration.java
+++ b/src/main/java/com/zestedesavoir/zestwriter/utils/Configuration.java
@@ -224,8 +224,10 @@ public class Configuration {
      * Zest-Writer options
      */
     public String getWorkspacePath(){
-        if(conf.containsKey(ConfigData.WorkspacePath.getKey()))
-            return conf.getProperty(ConfigData.WorkspacePath.getKey());
+        String workspacePath = conf.getProperty(ConfigData.WorkspacePath.getKey());
+
+        if(workspacePath != null && !workspacePath.isEmpty())
+            return workspacePath;
         else
             return Configuration.getDefaultWorkspace();
     }


### PR DESCRIPTION
**Ticket de référence** : 

**Objet de la PR** : 

Une absence de valeur pour la clé "options.workspace.path" dans le fichier de configuration, pouvait mener à une "runtime exception". L'idée étant que si la clé "options.workspace.path" était vide, la méthode retournais `null` et LocalDirectoryServer tente de créé un fichier sur `null`, ce qui à une tendance à ne pas bien marcher.

L'execption, que j'ai eu:

```
java.lang.reflect.InvocationTargetException
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at com.sun.javafx.application.LauncherImpl.launchApplicationWithArgs(LauncherImpl.java:389)
    at com.sun.javafx.application.LauncherImpl.launchApplication(LauncherImpl.java:328)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at sun.launcher.LauncherHelper$FXHelper.main(LauncherHelper.java:767)
Caused by: java.lang.RuntimeException: Unable to construct Application instance: class com.zestedesavoir.zestwriter.MainApp
    at com.sun.javafx.application.LauncherImpl.launchApplication1(LauncherImpl.java:907)
    at com.sun.javafx.application.LauncherImpl.lambda$launchApplication$155(LauncherImpl.java:182)
    at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.reflect.InvocationTargetException
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
    at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
    at com.sun.javafx.application.LauncherImpl.lambda$launchApplication1$161(LauncherImpl.java:819)
    at com.sun.javafx.application.PlatformImpl.lambda$runAndWait$175(PlatformImpl.java:326)
    at com.sun.javafx.application.PlatformImpl.lambda$null$173(PlatformImpl.java:295)
    at java.security.AccessController.doPrivileged(Native Method)
    at com.sun.javafx.application.PlatformImpl.lambda$runLater$174(PlatformImpl.java:294)
    at com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java:95)
    at com.sun.glass.ui.win.WinApplication._runLoop(Native Method)
    at com.sun.glass.ui.win.WinApplication.lambda$null$148(WinApplication.java:191)
    ... 1 more
Caused by: java.lang.RuntimeException: Could not create 
    at com.zestedesavoir.zestwriter.utils.LocalDirectorySaver.openDirCreateIfNecessary(LocalDirectorySaver.java:36)
    at com.zestedesavoir.zestwriter.utils.LocalDirectorySaver.<init>(LocalDirectorySaver.java:21)
    at com.zestedesavoir.zestwriter.utils.LocalDirectoryFactory.<init>(LocalDirectoryFactory.java:20)
    at com.zestedesavoir.zestwriter.utils.Configuration.loadWorkspace(Configuration.java:162)
    at com.zestedesavoir.zestwriter.utils.Configuration.initConf(Configuration.java:111)
    at com.zestedesavoir.zestwriter.utils.Configuration.<init>(Configuration.java:41)
    at com.zestedesavoir.zestwriter.MainApp.<init>(MainApp.java:62)
    ... 13 more
Exception running application com.zestedesavoir.zestwriter.MainApp
```

**Pour reproduire** :
- Dans le fichier conf.properties, ne pas mettre de valeur pour la clé "options.workspace.path".
