### PR TITLE
Fix #162 : Les contenus téléchargé n'apparaissent pas dans les projets récent

### DIFF
--- a/src/main/java/com/zestedesavoir/zestwriter/view/MenuController.java
+++ b/src/main/java/com/zestedesavoir/zestwriter/view/MenuController.java
@@ -389,6 +389,9 @@ public class MenuController{
                     alert.setContentText(Configuration.bundle.getString("ui.alert.download.success.text"));
                     alert.showAndWait();
                     hBottomBox.getChildren().clear();
+
+                    mainApp.getIndex().refreshRecentProject();
+
                     break;
             }
         });


### PR DESCRIPTION
**Ticket de référence** : #162 

**Objet de la PR** : 

Aprés la synchronisation, les contenus sont affiché dans la zone des projects ouvert.

Reprise de l'ancienne.
