### PR TITLE
1.3.0 hotfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ bin
 /.nb-gradle/
 *.log
 classes/
+out/

--- a/src/main/java/com/zestedesavoir/zestwriter/view/dialogs/MdCheatSheetDialog.java
+++ b/src/main/java/com/zestedesavoir/zestwriter/view/dialogs/MdCheatSheetDialog.java
@@ -1,6 +1,5 @@
 package com.zestedesavoir.zestwriter.view.dialogs;
 
-import com.kenai.jffi.Main;
 import com.zestedesavoir.zestwriter.MainApp;
 import com.zestedesavoir.zestwriter.utils.Configuration;
 import javafx.fxml.FXML;
@@ -12,7 +11,6 @@ import org.slf4j.LoggerFactory;
 import org.zeroturnaround.zip.commons.IOUtils;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;

--- a/src/main/resources/com/zestedesavoir/zestwriter/assets/static/html/zMdCheatSheet.html
+++ b/src/main/resources/com/zestedesavoir/zestwriter/assets/static/html/zMdCheatSheet.html
@@ -329,23 +329,23 @@ paragraphe
                 <p><code>http://www.zestedesavoir.com</code></p>
             </td>
             <td colspan="1" rowspan="1">
-                <p><a href="http://www.zestedesavoir.com">http://www.zestedesavoir.com</a></p>
+                <p><a href="https://zestedesavoir.com" onclick="event.preventDefault();">https://zestedesavoir.com</a></p>
             </td>
         </tr>
         <tr>
             <td colspan="1" rowspan="1">
-                <p><code>[un super site](http://www.zestedesavoir.com)</code></p>
+                <p><code>[un super site](https://zestedesavoir.com)</code></p>
             </td>
             <td colspan="1" rowspan="1">
-                <p><a href="http://www.zestedesavoir.com">un super site</a></p>
+                <p><a href="https://zestedesavoir.com" onclick="event.preventDefault();">un super site</a></p>
             </td>
         </tr>
         <tr>
             <td colspan="1" rowspan="1">
-                <p><code>[un super site](http://www.zestedesavoir.com "avec une infobulle")</code></p>
+                <p><code>[un super site](https://zestedesavoir.com "avec une infobulle")</code></p>
             </td>
             <td colspan="1" rowspan="1">
-                <p><a href="http://www.zestedesavoir.com" title="avec une infobulle">un super site</a></p>
+                <p><a href="https://zestedesavoir.com" title="avec une infobulle" onclick="event.preventDefault();">un super site</a></p>
             </td>
         </tr>
         <tr>
@@ -353,7 +353,7 @@ paragraphe
                 <p><code>[nous contacter](mailto:contact@example.com)</code></p>
             </td>
             <td colspan="1" rowspan="1">
-                <p><a href="mailto:contact%40example.com">nous contacter</a></p>
+                <p><a href="mailto:contact@example.com" onclick="event.preventDefault();">nous contacter</a></p>
             </td>
         </tr>
         <tr>
@@ -361,7 +361,7 @@ paragraphe
                 <p><code>contact@example.com</code></p>
             </td>
             <td colspan="1" rowspan="1">
-                <p><a href="mailto:contact@example.com">contact@example.com</a></p>
+                <p><a href="mailto:contact@example.com" onclick="event.preventDefault();">contact@example.com</a></p>
             </td>
         </tr>
         </tbody>
@@ -573,7 +573,7 @@ Table: ma table
         </tbody>
     </table>
 </div>
-<p>Plus d'informations sur : <a href="http://zestedesavoir.com/tutoriels/202/comment-rediger-des-maths-sur-zeste-de-savoir/">http://zestedesavoir.com/tutoriels/202/comment-rediger-des-maths-sur-zeste-de-savoir/</a></p>
+<p>Plus d'informations sur : <a href="https://zestedesavoir.com/tutoriels/202/comment-rediger-des-maths-sur-zeste-de-savoir/" onclick="event.preventDefault();">https://zestedesavoir.com/tutoriels/202/comment-rediger-des-maths-sur-zeste-de-savoir/</a></p>
 
 <!--code-->
 
@@ -600,7 +600,7 @@ print("Hello, World!")
 </pre></div>
 </td></tr></tbody></table>
 
-<p>le code des langages correspondent aux short names de <a href="http://pygments.org/docs/lexers">la cette liste</a> (pygment).</p>
+<p>le code des langages correspondent aux short names de cette liste: <a href="http://pygments.org/docs/lexers" onclick="event.preventDefault();">http://pygments.org/docs/lexers</a>.</p>
 <p>Vous pouvez également indenter votre texte par quatre espaces pour le formater :</p>
 <table class="codehilitetable"><tbody><tr><td class="linenos"><div class="linenodiv"><pre>1
 2


### PR DESCRIPTION
**Ticket de référence** : Aucun

**Objet de la PR** :  Hotfix de la version 1.3.0

Ce qui a été corrigé:
- Les liens dans l'aide zMarkdown ne sont plus directement ouvert si on clique dessus (Mais on peut soit faire `clic droit, copier le lien`, ou `clic droit, ouvrir`, ce qui aura pour effet de tout de même l'ouvrir dans la fenêtre de l'aide.

Edit: Sinon c'est cool pour le problème de connexion, il me semble qu'on la quasiment résolu chez tout le monde.
