### PR TITLE
Wip zmarkdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ build/
 doc/build/
 doc/rst/.presentation.rst
 
+#Sonar database backup
+sonar-database
+
 # Misc
 *.log
 venv/

--- a/build.gradle
+++ b/build.gradle
@@ -139,6 +139,7 @@ dependencies {
     compile group: 'com.openhtmltopdf', name: 'openhtmltopdf-pdfbox', version: '0.0.1-RC11'
     compile group: 'com.openhtmltopdf', name: 'openhtmltopdf-jsoup-dom-converter', version: '0.0.1-RC11'
     compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.8.0'
+    compile group: 'com.vladsch.flexmark', name: 'flexmark', version: '0.26.4'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -139,7 +139,7 @@ dependencies {
     compile group: 'com.openhtmltopdf', name: 'openhtmltopdf-pdfbox', version: '0.0.1-RC11'
     compile group: 'com.openhtmltopdf', name: 'openhtmltopdf-jsoup-dom-converter', version: '0.0.1-RC11'
     compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.8.0'
-    compile group: 'com.vladsch.flexmark', name: 'flexmark', version: '0.26.4'
+    compile group: 'com.vladsch.flexmark', name: 'flexmark-all', version: '0.26.4'
 }
 
 test {

--- a/src/main/java/com/zestedesavoir/zestwriter/MainApp.java
+++ b/src/main/java/com/zestedesavoir/zestwriter/MainApp.java
@@ -18,16 +18,13 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import javafx.collections.ObservableMap;
 import javafx.event.ActionEvent;
-import javafx.event.EventHandler;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Scene;
 import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.Dialog;
-import javafx.scene.control.Tab;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.KeyEvent;
@@ -45,7 +42,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashMap;
 
 public class MainApp extends Application{
     private static Configuration config;

--- a/src/main/java/com/zestedesavoir/zestwriter/model/Content.java
+++ b/src/main/java/com/zestedesavoir/zestwriter/model/Content.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.zestedesavoir.zestwriter.MainApp;
 import com.zestedesavoir.zestwriter.model.markdown.ZMarkdown;
 import com.zestedesavoir.zestwriter.utils.ZdsHttp;
-import com.zestedesavoir.zestwriter.view.MdTextController;
 import com.zestedesavoir.zestwriter.view.com.FunctionTreeFactory;
 import com.zestedesavoir.zestwriter.view.com.IconFactory;
 import de.jensd.fx.glyphs.materialdesignicons.MaterialDesignIconView;

--- a/src/main/java/com/zestedesavoir/zestwriter/model/Content.java
+++ b/src/main/java/com/zestedesavoir/zestwriter/model/Content.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.zestedesavoir.zestwriter.MainApp;
+import com.zestedesavoir.zestwriter.model.markdown.ZMarkdown;
 import com.zestedesavoir.zestwriter.utils.ZdsHttp;
 import com.zestedesavoir.zestwriter.view.MdTextController;
 import com.zestedesavoir.zestwriter.view.com.FunctionTreeFactory;
@@ -159,11 +160,11 @@ public class Content extends Container implements ContentNode{
         return htmlValue;
     }
 
-    public void saveToHtml(File file, MdTextController index) {
+    public void saveToHtml(File file) {
         try (FileOutputStream fos = new FileOutputStream(file)) {
             BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(fos, "UTF8"));
             String mdValue = exportContentToMarkdown(0, getDepth());
-            String htmlValue = StringEscapeUtils.unescapeHtml4(index.markdownToHtml(mdValue));
+            String htmlValue = StringEscapeUtils.unescapeHtml4(ZMarkdown.markdownToHtml(mdValue));
             htmlValue = normalizeHtml(htmlValue);
             writer.append(MainApp.getMdUtils().addHeaderAndFooterStrict(htmlValue, getTitle()));
             writer.flush();

--- a/src/main/java/com/zestedesavoir/zestwriter/model/License.java
+++ b/src/main/java/com/zestedesavoir/zestwriter/model/License.java
@@ -1,6 +1,5 @@
 package com.zestedesavoir.zestwriter.model;
 
-import com.zestedesavoir.zestwriter.utils.Lang;
 import com.zestedesavoir.zestwriter.view.dialogs.EditContentDialog;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/zestedesavoir/zestwriter/model/markdown/ZMarkdown.java
+++ b/src/main/java/com/zestedesavoir/zestwriter/model/markdown/ZMarkdown.java
@@ -1,0 +1,22 @@
+package com.zestedesavoir.zestwriter.model.markdown;
+
+import com.vladsch.flexmark.ast.Node;
+import com.vladsch.flexmark.html.HtmlRenderer;
+import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.util.options.MutableDataSet;
+
+/**
+ * Created by: WinXaito (Kevin Vuilleumier)
+ */
+public class ZMarkdown{
+    private static MutableDataSet options = new MutableDataSet();
+    private static Parser parser = Parser.builder(options).build();
+    private static HtmlRenderer renderer = HtmlRenderer.builder(options).build();
+
+    public static String markdownToHtml(String markdown){
+        // You can re-use parser and renderer instances
+        System.out.println("ZMarkdown: render");
+        Node document = parser.parse(markdown);
+        return renderer.render(document);
+    }
+}

--- a/src/main/java/com/zestedesavoir/zestwriter/model/markdown/ZMarkdown.java
+++ b/src/main/java/com/zestedesavoir/zestwriter/model/markdown/ZMarkdown.java
@@ -1,22 +1,57 @@
 package com.zestedesavoir.zestwriter.model.markdown;
 
 import com.vladsch.flexmark.ast.Node;
+import com.vladsch.flexmark.ext.anchorlink.AnchorLinkExtension;
+import com.vladsch.flexmark.ext.aside.AsideExtension;
+import com.vladsch.flexmark.ext.autolink.AutolinkExtension;
+import com.vladsch.flexmark.ext.definition.DefinitionExtension;
+import com.vladsch.flexmark.ext.emoji.EmojiExtension;
+import com.vladsch.flexmark.ext.footnotes.FootnoteExtension;
+import com.vladsch.flexmark.ext.gfm.issues.GfmIssuesExtension;
+import com.vladsch.flexmark.ext.tables.TablesExtension;
 import com.vladsch.flexmark.html.HtmlRenderer;
 import com.vladsch.flexmark.parser.Parser;
 import com.vladsch.flexmark.util.options.MutableDataSet;
+import com.vladsch.flexmark.util.sequence.BasedSequence;
+
+import java.util.Arrays;
 
 /**
  * Created by: WinXaito (Kevin Vuilleumier)
  */
 public class ZMarkdown{
-    private static MutableDataSet options = new MutableDataSet();
-    private static Parser parser = Parser.builder(options).build();
-    private static HtmlRenderer renderer = HtmlRenderer.builder(options).build();
+    private static Parser parser;
+    private static HtmlRenderer renderer;
+    private static boolean init = false;
+
+    private static void init(){
+        init = true;
+
+        MutableDataSet options = new MutableDataSet()
+                .set(Parser.EXTENSIONS, Arrays.asList(
+                        TablesExtension.create(),
+                        AnchorLinkExtension.create(),
+                        AsideExtension.create(),
+                        AutolinkExtension.create(),
+                        DefinitionExtension.create(),
+                        EmojiExtension.create(),
+                        FootnoteExtension.create(),
+                        GfmIssuesExtension.create()
+                ));
+
+
+        parser = Parser.builder(options).build();
+        renderer = HtmlRenderer.builder(options).build();
+    }
+
 
     public static String markdownToHtml(String markdown){
+        if(!init)
+            init();
+
         // You can re-use parser and renderer instances
         System.out.println("ZMarkdown: render");
-        Node document = parser.parse(markdown);
+        Node document = parser.parse("ZMarkdown" + markdown);
         return renderer.render(document);
     }
 }

--- a/src/main/java/com/zestedesavoir/zestwriter/utils/Configuration.java
+++ b/src/main/java/com/zestedesavoir/zestwriter/utils/Configuration.java
@@ -2,7 +2,6 @@ package com.zestedesavoir.zestwriter.utils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zestedesavoir.zestwriter.MainApp;
-import com.zestedesavoir.zestwriter.view.dialogs.EditContentDialog;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.http.client.fluent.Request;

--- a/src/main/java/com/zestedesavoir/zestwriter/utils/Corrector.java
+++ b/src/main/java/com/zestedesavoir/zestwriter/utils/Corrector.java
@@ -1,8 +1,6 @@
 package com.zestedesavoir.zestwriter.utils;
 
 import com.zestedesavoir.zestwriter.model.markdown.ZMarkdown;
-import com.zestedesavoir.zestwriter.view.MdTextController;
-import com.zestedesavoir.zestwriter.view.MenuController;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.jsoup.Jsoup;

--- a/src/main/java/com/zestedesavoir/zestwriter/utils/Corrector.java
+++ b/src/main/java/com/zestedesavoir/zestwriter/utils/Corrector.java
@@ -1,5 +1,6 @@
 package com.zestedesavoir.zestwriter.utils;
 
+import com.zestedesavoir.zestwriter.model.markdown.ZMarkdown;
 import com.zestedesavoir.zestwriter.view.MdTextController;
 import com.zestedesavoir.zestwriter.view.MenuController;
 import lombok.extern.slf4j.Slf4j;
@@ -211,8 +212,8 @@ public class Corrector {
         return bf.toString();
     }
 
-    public int countMistakes(MdTextController mdTextController, String markdown) {
-        String htmlText = StringEscapeUtils.unescapeHtml4(MenuController.markdownToHtml(mdTextController, markdown));
+    public int countMistakes(String markdown) {
+        String htmlText = StringEscapeUtils.unescapeHtml4(ZMarkdown.markdownToHtml(markdown));
         AnnotatedText markup = makeAnnotatedText(htmlText);
 
         langTool.getAllActiveRules().stream()

--- a/src/main/java/com/zestedesavoir/zestwriter/utils/Lang.java
+++ b/src/main/java/com/zestedesavoir/zestwriter/utils/Lang.java
@@ -3,7 +3,6 @@ package com.zestedesavoir.zestwriter.utils;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/com/zestedesavoir/zestwriter/utils/Theme.java
+++ b/src/main/java/com/zestedesavoir/zestwriter/utils/Theme.java
@@ -3,7 +3,6 @@ package com.zestedesavoir.zestwriter.utils;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 
 import java.util.Arrays;
 import java.util.Calendar;

--- a/src/main/java/com/zestedesavoir/zestwriter/view/MdConvertController.java
+++ b/src/main/java/com/zestedesavoir/zestwriter/view/MdConvertController.java
@@ -3,6 +3,7 @@ package com.zestedesavoir.zestwriter.view;
 import com.zestedesavoir.zestwriter.MainApp;
 import com.zestedesavoir.zestwriter.model.ContentNode;
 import com.zestedesavoir.zestwriter.model.Textual;
+import com.zestedesavoir.zestwriter.model.markdown.ZMarkdown;
 import com.zestedesavoir.zestwriter.utils.Configuration;
 import com.zestedesavoir.zestwriter.utils.Corrector;
 import com.zestedesavoir.zestwriter.utils.readability.Readability;
@@ -152,7 +153,7 @@ public class MdConvertController {
                 return new Task<String>() {
                     @Override
                     protected String call() throws Exception {
-                        String html = getMdBox().markdownToHtml(sourceText.getText());
+                        String html = ZMarkdown.markdownToHtml(sourceText.getText());
                         if (html != null) {
                             return MainApp.getMdUtils().addHeaderAndFooter(html);
                         } else {
@@ -163,9 +164,7 @@ public class MdConvertController {
             }
         };
 
-        renderTask.setOnFailed(t -> {
-            renderTask.restart();
-        });
+        renderTask.setOnFailed(t -> renderTask.restart());
 
         renderTask.setOnSucceeded(t -> {
             Platform.runLater(() -> {

--- a/src/main/java/com/zestedesavoir/zestwriter/view/MenuController.java
+++ b/src/main/java/com/zestedesavoir/zestwriter/view/MenuController.java
@@ -3,6 +3,7 @@ package com.zestedesavoir.zestwriter.view;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zestedesavoir.zestwriter.MainApp;
 import com.zestedesavoir.zestwriter.model.*;
+import com.zestedesavoir.zestwriter.model.markdown.ZMarkdown;
 import com.zestedesavoir.zestwriter.utils.Configuration;
 import com.zestedesavoir.zestwriter.utils.Corrector;
 import com.zestedesavoir.zestwriter.utils.ZdsHttp;
@@ -46,8 +47,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.fxmisc.richtext.StyleClassedTextArea;
-import org.python.core.PyString;
-import org.python.util.PythonInterpreter;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -79,14 +78,6 @@ public class MenuController{
     @FXML private MenuItem menuQuit;
     @FXML private MenuItem menuFindReplace;
     private BooleanPropertyBase isOnReadingTab = new SimpleBooleanProperty(true);
-
-    public static String markdownToHtml(MdTextController index, String chaine) {
-        PythonInterpreter console = index.getPyconsole();
-        console.set("text", chaine);
-        console.exec("render = mk_instance.convert(text)");
-        PyString render = console.get("render", PyString.class);
-        return render.toString();
-    }
 
     public BooleanPropertyBase isOnReadingTabProperty() {
         return isOnReadingTab;
@@ -135,7 +126,7 @@ public class MenuController{
 
     @FXML private void handleFleshButtonAction(ActionEvent event){
         Function<Textual, Double> calFlesh = (Textual ch) -> {
-            String htmlText = StringEscapeUtils.unescapeHtml4(markdownToHtml(mainApp.getIndex(), ch.readMarkdown()));
+            String htmlText = StringEscapeUtils.unescapeHtml4(ZMarkdown.markdownToHtml(ch.readMarkdown()));
             String plainText = Corrector.htmlToTextWithoutCode(htmlText);
             if("".equals(plainText.trim())){
                 return 100.0;
@@ -159,7 +150,7 @@ public class MenuController{
 
     @FXML private void handleGunningButtonAction(ActionEvent event){
         Function<Textual, Double> calGuning = (Textual ch) -> {
-            String htmlText = StringEscapeUtils.unescapeHtml4(markdownToHtml(mainApp.getIndex(), ch.readMarkdown()));
+            String htmlText = StringEscapeUtils.unescapeHtml4(ZMarkdown.markdownToHtml(ch.readMarkdown()));
             String plainText = Corrector.htmlToTextWithoutCode(htmlText);
             if("".equals(plainText.trim())){
                 return 100.0;
@@ -632,7 +623,7 @@ public class MenuController{
             hBottomBox.getChildren().clear();
             hBottomBox.add(pb, 0, 0);
             hBottomBox.add(labelField, 1, 0);
-            ExportPdfService exportPdfTask = new ExportPdfService(mainApp.getIndex(), content, selectedFile);
+            ExportPdfService exportPdfTask = new ExportPdfService(content, selectedFile);
             labelField.textProperty().bind(exportPdfTask.messageProperty());
             pb.progressProperty().bind(exportPdfTask.progressProperty());
             Alert alert = new CustomAlert(AlertType.NONE);

--- a/src/main/java/com/zestedesavoir/zestwriter/view/MenuController.java
+++ b/src/main/java/com/zestedesavoir/zestwriter/view/MenuController.java
@@ -11,7 +11,6 @@ import com.zestedesavoir.zestwriter.utils.readability.Readability;
 import com.zestedesavoir.zestwriter.view.com.*;
 import com.zestedesavoir.zestwriter.view.dialogs.*;
 import com.zestedesavoir.zestwriter.view.task.*;
-import edu.berkeley.nlp.lm.io.IOUtils;
 import javafx.beans.property.BooleanPropertyBase;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.collections.FXCollections;
@@ -49,9 +48,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.fxmisc.richtext.StyleClassedTextArea;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/zestedesavoir/zestwriter/view/com/MdTreeCell.java
+++ b/src/main/java/com/zestedesavoir/zestwriter/view/com/MdTreeCell.java
@@ -3,6 +3,7 @@ package com.zestedesavoir.zestwriter.view.com;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zestedesavoir.zestwriter.MainApp;
 import com.zestedesavoir.zestwriter.model.*;
+import com.zestedesavoir.zestwriter.model.markdown.ZMarkdown;
 import com.zestedesavoir.zestwriter.utils.Configuration;
 import com.zestedesavoir.zestwriter.utils.Corrector;
 import com.zestedesavoir.zestwriter.utils.ZdsHttp;
@@ -389,7 +390,7 @@ public class MdTreeCell extends TreeCell<ContentNode>{
             logger.debug("Tentative de calcul des statistiques de lisiblité");
             Container container = (Container) getItem();
             Function<Textual, Double> performGuning = (Textual ch) -> {
-                String htmlText = StringEscapeUtils.unescapeHtml4(MenuController.markdownToHtml(index, ch.readMarkdown()));
+                String htmlText = StringEscapeUtils.unescapeHtml4(ZMarkdown.markdownToHtml(ch.readMarkdown()));
                 String plainText = Corrector.htmlToTextWithoutCode(htmlText);
                 if("".equals(plainText.trim())){
                     return 100.0;
@@ -399,7 +400,7 @@ public class MdTreeCell extends TreeCell<ContentNode>{
                 }
             };
             Function<Textual, Double> performFlesch = (Textual ch) -> {
-                String htmlText = StringEscapeUtils.unescapeHtml4(MenuController.markdownToHtml(index, ch.readMarkdown()));
+                String htmlText = StringEscapeUtils.unescapeHtml4(ZMarkdown.markdownToHtml(ch.readMarkdown()));
                 String plainText = Corrector.htmlToTextWithoutCode(htmlText);
                 if("".equals(plainText.trim())){
                     return 100.0;
@@ -434,7 +435,7 @@ public class MdTreeCell extends TreeCell<ContentNode>{
             Function<Textual, Double> performCorrection = (Textual ch) -> {
                 String md = ch.readMarkdown();
                 try {
-                    return (double) corrector.countMistakes(index, md);
+                    return (double) corrector.countMistakes(md);
                 } catch(Exception e) {
                     logger.trace(e.getMessage(), e);
                     return 0.0;

--- a/src/main/java/com/zestedesavoir/zestwriter/view/com/MdTreeCell.java
+++ b/src/main/java/com/zestedesavoir/zestwriter/view/com/MdTreeCell.java
@@ -9,7 +9,6 @@ import com.zestedesavoir.zestwriter.utils.Corrector;
 import com.zestedesavoir.zestwriter.utils.ZdsHttp;
 import com.zestedesavoir.zestwriter.utils.readability.Readability;
 import com.zestedesavoir.zestwriter.view.MdTextController;
-import com.zestedesavoir.zestwriter.view.MenuController;
 import com.zestedesavoir.zestwriter.view.dialogs.BaseDialog;
 import com.zestedesavoir.zestwriter.view.task.ComputeIndexService;
 import javafx.scene.chart.*;

--- a/src/main/java/com/zestedesavoir/zestwriter/view/task/CorrectionService.java
+++ b/src/main/java/com/zestedesavoir/zestwriter/view/task/CorrectionService.java
@@ -1,13 +1,11 @@
 package com.zestedesavoir.zestwriter.view.task;
 
-import com.zestedesavoir.zestwriter.MainApp;
 import com.zestedesavoir.zestwriter.model.Content;
 import com.zestedesavoir.zestwriter.model.Textual;
 import com.zestedesavoir.zestwriter.model.markdown.ZMarkdown;
 import com.zestedesavoir.zestwriter.utils.Configuration;
 import com.zestedesavoir.zestwriter.utils.Corrector;
 import com.zestedesavoir.zestwriter.view.MdTextController;
-import com.zestedesavoir.zestwriter.view.MenuController;
 import javafx.concurrent.Service;
 import javafx.concurrent.Task;
 import org.apache.commons.lang3.StringEscapeUtils;

--- a/src/main/java/com/zestedesavoir/zestwriter/view/task/CorrectionService.java
+++ b/src/main/java/com/zestedesavoir/zestwriter/view/task/CorrectionService.java
@@ -3,6 +3,7 @@ package com.zestedesavoir.zestwriter.view.task;
 import com.zestedesavoir.zestwriter.MainApp;
 import com.zestedesavoir.zestwriter.model.Content;
 import com.zestedesavoir.zestwriter.model.Textual;
+import com.zestedesavoir.zestwriter.model.markdown.ZMarkdown;
 import com.zestedesavoir.zestwriter.utils.Configuration;
 import com.zestedesavoir.zestwriter.utils.Corrector;
 import com.zestedesavoir.zestwriter.view.MdTextController;
@@ -17,11 +18,9 @@ import java.util.function.Function;
 
 public class CorrectionService extends Service<String>{
 	private Corrector corrector;
-	private MdTextController mdText;
 	private Content content;
 
 	public CorrectionService(MdTextController mdText) {
-		this.mdText = mdText;
 		this.content = (Content) mdText.getSummary().getRoot().getValue();
 		corrector = new Corrector();
 	}
@@ -36,13 +35,8 @@ public class CorrectionService extends Service<String>{
                 Function<Textual, String> prepareValidationReport = (Textual ext) -> {
                     updateMessage(ext.getTitle());
                     String markdown = ext.readMarkdown();
-                    if(!mdText.isPythonStarted()) {
-                        MainApp.getLogger().debug("Jython en cours de chargement mémoire");
-                        return null;
-                    } else {
-                        String htmlText = StringEscapeUtils.unescapeHtml4(MenuController.markdownToHtml(mdText, markdown));
-                        return corrector.checkHtmlContentToText(htmlText, ext.getTitle());
-                    }
+                    String htmlText = StringEscapeUtils.unescapeHtml4(ZMarkdown.markdownToHtml(markdown));
+                    return corrector.checkHtmlContentToText(htmlText, ext.getTitle());
                 };
                 Map<Textual, String> validationResult = content.doOnTextual(prepareValidationReport);
 

--- a/src/main/java/com/zestedesavoir/zestwriter/view/task/ExportPdfService.java
+++ b/src/main/java/com/zestedesavoir/zestwriter/view/task/ExportPdfService.java
@@ -1,30 +1,15 @@
 package com.zestedesavoir.zestwriter.view.task;
 
-import com.zestedesavoir.zestwriter.MainApp;
 import com.zestedesavoir.zestwriter.model.Content;
 import com.zestedesavoir.zestwriter.utils.Configuration;
 import com.zestedesavoir.zestwriter.utils.PdfUtilExport;
 import com.zestedesavoir.zestwriter.utils.ZdsHttp;
-import com.zestedesavoir.zestwriter.view.MdTextController;
 import javafx.concurrent.Service;
 import javafx.concurrent.Task;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.mime.HttpMultipartMode;
-import org.apache.http.entity.mime.MultipartEntityBuilder;
-import org.apache.http.entity.mime.content.FileBody;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.LaxRedirectStrategy;
-import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 
 @Slf4j
 public class ExportPdfService extends Service<Void>{

--- a/src/main/java/com/zestedesavoir/zestwriter/view/task/ExportPdfService.java
+++ b/src/main/java/com/zestedesavoir/zestwriter/view/task/ExportPdfService.java
@@ -28,16 +28,13 @@ import java.io.InputStream;
 
 @Slf4j
 public class ExportPdfService extends Service<Void>{
-
     private File fileDest;
     private Content content;
-    private MdTextController index;
     private File htmlFile;
 
-    public ExportPdfService(MdTextController index, Content content, File fileDest) {
+    public ExportPdfService(Content content, File fileDest) {
         this.fileDest = fileDest;
         this.content = content;
-        this.index = index;
         htmlFile = new File(System.getProperty("java.io.tmpdir"), ZdsHttp.toSlug(content.getTitle()) + ".html");
     }
 
@@ -52,7 +49,7 @@ public class ExportPdfService extends Service<Void>{
             @Override
             protected Void call() throws Exception {
                 updateMessage(Configuration.getBundle().getString("ui.task.export.assemble.label"));
-                content.saveToHtml(htmlFile, index);
+                content.saveToHtml(htmlFile);
 
                 updateMessage(Configuration.getBundle().getString("ui.task.export.label"));
                 PdfUtilExport act = new PdfUtilExport(content.getTitle(), content.getLicence(), "file://"+htmlFile, fileDest.getAbsolutePath());

--- a/src/test/java/TestMarkdown.java
+++ b/src/test/java/TestMarkdown.java
@@ -1,35 +1,15 @@
-import org.junit.Before;
+import com.zestedesavoir.zestwriter.model.markdown.ZMarkdown;
 import org.junit.Test;
-import org.python.core.PyString;
-import org.python.util.PythonInterpreter;
 
 import static org.junit.Assert.assertEquals;
 
 public class TestMarkdown {
-
-    PythonInterpreter pyconsole;
-
-    @Before
-    public void Setup() {
-        pyconsole = new PythonInterpreter();
-    }
-
     @Test
     public void test() {
         String strBefore = "Bonjour `Set<Class<? extends Object>>`";
         String strAfter = "<p>Bonjour <code>Set&lt;Class&lt;? extends Object&gt;&gt;</code></p>";
 
-        pyconsole.exec("from markdown import Markdown");
-        pyconsole.exec("from markdown.extensions.zds import ZdsExtension");
-        pyconsole.exec("from smileys_definition import smileys");
-
-        pyconsole.set("text", strBefore);
-        pyconsole.exec("mk_instance = Markdown(extensions=(ZdsExtension(inline=False, emoticons=smileys, js_support=False, ping_url=None),),safe_mode = 'escape', enable_attributes = False, tab_length = 4, output_format = 'html5', smart_emphasis = True, lazy_ol = True)");
-        pyconsole.exec("render = mk_instance.convert(text)");
-
-        PyString render = pyconsole.get("render", PyString.class);
-        assertEquals(render.toString(), strAfter);
-
+        assertEquals(ZMarkdown.markdownToHtml(strBefore), strAfter);
     }
 
 }


### PR DESCRIPTION
**Ticket de référence** : #316 

**Objet de la PR** : Passage de python-zmarkdown à flexmark

Bon, je crois que je commence à comprendre pourquoi tu es parti sur du Jython plutôt que sur un éditeur Markdown, car il y aura du job, et beaucoup à mon avis.

Je ne pensais pas que le ZMarkdown était si différent. Après il y a certaine option qu'on doit pouvoir modifier j'image (j'espère), par exemple le fait qu'il est nécessaire d'avoir un espace après les `##` pour faire un titre.

Et pour les extensions j'ai regardé, mais je dois bien admettre que je suis largué, et c'est pas ma facilité en anglais qui aide le tout.
